### PR TITLE
Docker provider, style fix for nginx_image_version variable.

### DIFF
--- a/part01-docker-provider/main.tf
+++ b/part01-docker-provider/main.tf
@@ -1,7 +1,7 @@
 # Create a docker image resource
 # -> docker pull nginx:latest
 resource "docker_image" "nginx" {
-  name         = var.ngins_image_version
+  name         = var.nginx_image_version
   keep_locally = var.keep_locally
   force_remove = var.force_remove
 }

--- a/part01-docker-provider/variables.tf
+++ b/part01-docker-provider/variables.tf
@@ -3,7 +3,7 @@ variable "nginx_version" {
   type        = string
   description = "value of the nginx container tag"
 }
-variable "ngins_image_version" {
+variable "nginx_image_version" {
   default     = "nginx:latest"
   type        = string
   description = "value of nginex version"


### PR DESCRIPTION
# Changes:
This fixes the name of nginx_image_version due to the #32 issue report.
The incorrect value name was `ngins_image_version` which changed to `nginx_image_version`.
