### PR TITLE
Add simple arvancloud abrak module

### DIFF
--- a/part20-arvancloud-abrak/.gitignore
+++ b/part20-arvancloud-abrak/.gitignore
@@ -1,1 +1,29 @@
-key
+# Local .terraform directories
+**/.terraform/*
+
+# Terraform lockfile
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/part20-arvancloud-abrak/main.tf
+++ b/part20-arvancloud-abrak/main.tf
@@ -7,22 +7,14 @@ terraform {
   }
 }
 
-resource "arvan_iaas_abrak" "abrak-1" {
+module "abrak" {
+  source = "./modules/abrak"
+  abrak_name = var.abrak_name
   region = var.region
-  flavor = "g1-1-1-0"
-  name   = var.abrak-name
-  image {
+  abrak_flavor = "g1-1-1-0"
+  abrak_image = {
     type = "distributions"
     name = "debian/11"
   }
-  disk_size = 25
-}
-
-data "arvan_iaas_abrak" "get_abrak_id" {
-  depends_on = [
-    arvan_iaas_abrak.abrak-1
-  ]
-
-  region = var.region
-  name   = var.abrak-name
+  abrak_disk_size = 25
 }

--- a/part20-arvancloud-abrak/modules/abrak/.gitignore
+++ b/part20-arvancloud-abrak/modules/abrak/.gitignore
@@ -1,0 +1,29 @@
+# Local .terraform directories
+**/.terraform/*
+
+# Terraform lockfile
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/part20-arvancloud-abrak/modules/abrak/README.md
+++ b/part20-arvancloud-abrak/modules/abrak/README.md
@@ -1,0 +1,39 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_arvan"></a> [arvan](#requirement\_arvan) | >=0.6.4 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_arvan"></a> [arvan](#provider\_arvan) | >=0.6.4 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [arvan_iaas_abrak.abrak](https://registry.terraform.io/providers/arvancloud/arvan/latest/docs/resources/iaas_abrak) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_abrak_disk_size"></a> [abrak\_disk\_size](#input\_abrak\_disk\_size) | Abrak disk size in GB | `number` | n/a | yes |
+| <a name="input_abrak_flavor"></a> [abrak\_flavor](#input\_abrak\_flavor) | Abrak plan ID, you can get list of plan IDs of each region from sizes api | `string` | n/a | yes |
+| <a name="input_abrak_ha_enabled"></a> [abrak\_ha\_enabled](#input\_abrak\_ha\_enabled) | HA feature in abrak. This feature is exprimental, May not works now. | `bool` | `false` | no |
+| <a name="input_abrak_image"></a> [abrak\_image](#input\_abrak\_image) | Abrak image type and name | <pre>object({<br>		type = string<br>		name = string<br>	})</pre> | n/a | yes |
+| <a name="input_abrak_name"></a> [abrak\_name](#input\_abrak\_name) | Abrak name in Arvancloud web console | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | Arvancloud region name. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | n/a |
+| <a name="output_ip_addresses"></a> [ip\_addresses](#output\_ip\_addresses) | n/a |

--- a/part20-arvancloud-abrak/modules/abrak/main.tf
+++ b/part20-arvancloud-abrak/modules/abrak/main.tf
@@ -1,0 +1,11 @@
+resource "arvan_iaas_abrak" "abrak" {
+  name   = var.abrak_name
+	region = var.region
+  flavor = var.abrak_flavor
+  disk_size = var.abrak_disk_size
+	ha_enabled = var.abrak_ha_enabled # This is exprimental feature, May not works
+  image {
+    type = var.abrak_image.type
+    name = var.abrak_image.name
+  }
+}

--- a/part20-arvancloud-abrak/modules/abrak/outputs.tf
+++ b/part20-arvancloud-abrak/modules/abrak/outputs.tf
@@ -1,0 +1,7 @@
+output "ip_addresses" {
+	value = "${arvan_iaas_abrak.abrak.addresses}"
+}
+
+output "id" {
+	value = "${arvan_iaas_abrak.abrak.id}"
+}

--- a/part20-arvancloud-abrak/modules/abrak/variables.tf
+++ b/part20-arvancloud-abrak/modules/abrak/variables.tf
@@ -1,0 +1,54 @@
+variable "region" {
+	description = "Arvancloud region name."
+  type = string
+  validation {
+    condition = contains(
+      [
+        "ir-thr-c2",  # Forogh
+        "ir-tbz-dc1", # Shahriar
+        "ir-thr-w1",  # Bamdad
+        "ir-thr-c1"   # Simin
+      ],
+			var.region
+    )
+    error_message = <<-EOF
+		"
+		Specify valid region name. Using the following available regions.
+		Forogh ==> ir-thr-c2
+		Shahriar ==> ir-tbz-dc1
+		Bamdad ==> ir-thr-w1
+		Simin ==> ir-thr-c1
+		"
+		EOF
+  }
+}
+
+variable "abrak_name" {
+	description = "Abrak name in Arvancloud web console"
+  type = string
+}
+
+variable "abrak_flavor" {
+	description = "Abrak plan ID, you can get list of plan IDs of each region from sizes api"
+	# Check "https://napi.arvancloud.ir/ecc/v1/regions/<region>/sizes" to find best falavor size.
+	type = string
+}
+
+variable "abrak_disk_size" {
+	description = "Abrak disk size in GB"
+	type = number
+}
+
+variable "abrak_ha_enabled" {
+	description = "HA feature in abrak. This feature is exprimental, May not works now."
+	type = bool
+  default = false
+}
+
+variable "abrak_image" {
+	description = "Abrak image type and name"
+	type = object({
+		type = string
+		name = string
+	})
+}

--- a/part20-arvancloud-abrak/modules/abrak/versions.tf
+++ b/part20-arvancloud-abrak/modules/abrak/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    arvan = {
+      source  = "arvancloud/arvan"
+      version = ">=0.6.4"
+    }
+  }
+}

--- a/part20-arvancloud-abrak/output.tf
+++ b/part20-arvancloud-abrak/output.tf
@@ -1,3 +1,7 @@
-output "details-abrak-1" {
-  value = data.arvan_iaas_abrak.get_abrak_id
+output "abrak_id" {
+  value = module.abrak.id
+}
+
+output "abrak_ip_addresses" {
+  value = module.abrak.ip_addresses
 }

--- a/part20-arvancloud-abrak/variables.tf
+++ b/part20-arvancloud-abrak/variables.tf
@@ -1,10 +1,9 @@
 variable "ApiKey" {
   type = string
-  default = "<your API-Key>"
   sensitive = true
 }
 
-variable "abrak-name" {
+variable "abrak_name" {
   type = string
   default = "terraform-abrak-example"
 }


### PR DESCRIPTION
Add simple Arvancloud module to Arvancloud samples. Module create with following steps:
1. add .gitignore to Arvancloud module
2. add minimum required provider version
3. define required variable with some description and validation
4. define main component of modules for create Arvancloud Abrak
5. define resources output to output section
6. create documents based on variables and outputs on README.md file
7. change old staff in base folder and change it to new required components

Future works:
Add following resources to project
1. define and configure security groups
2. define network subnet and attach to abrak
3. add ssh key to Abrak if it's defined
4. define a new volume and attach to Abrak