### PR TITLE
Add ssh key to arvancloud abrak module

### DIFF
--- a/part20-arvancloud-abrak/main.tf
+++ b/part20-arvancloud-abrak/main.tf
@@ -8,10 +8,12 @@ terraform {
 }
 
 module "abrak" {
-  source = "./modules/abrak"
-  abrak_name = var.abrak_name
-  region = var.region
-  abrak_flavor = "g1-1-1-0"
+  source               = "./modules/abrak"
+  abrak_name           = var.abrak_name
+  region               = var.region
+  abrak_sshkey_enabled = var.abrak_sshkey_enabled
+  abrak_sshkey_name    = "devopshobies"
+  abrak_flavor         = "g1-1-1-0"
   abrak_image = {
     type = "distributions"
     name = "debian/11"

--- a/part20-arvancloud-abrak/modules/abrak/main.tf
+++ b/part20-arvancloud-abrak/modules/abrak/main.tf
@@ -1,9 +1,23 @@
+resource "tls_private_key" "sshkey" {
+  count     = var.abrak_sshkey_enabled ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "arvan_iaas_sshkey" "sshkey_arvan" {
+  count      = var.abrak_sshkey_enabled ? 1 : 0
+  name       = var.abrak_sshkey_name
+  public_key = tls_private_key.sshkey[0].public_key_openssh
+  region     = var.region
+}
+
 resource "arvan_iaas_abrak" "abrak" {
-  name   = var.abrak_name
-	region = var.region
-  flavor = var.abrak_flavor
-  disk_size = var.abrak_disk_size
-	ha_enabled = var.abrak_ha_enabled # This is exprimental feature, May not works
+  name       = var.abrak_name
+  region     = var.region
+  flavor     = var.abrak_flavor
+  key_name   = var.abrak_sshkey_enabled ? arvan_iaas_sshkey.sshkey_arvan[0].name : null
+  disk_size  = var.abrak_disk_size
+  ha_enabled = var.abrak_ha_enabled # This is exprimental feature, May not works
   image {
     type = var.abrak_image.type
     name = var.abrak_image.name

--- a/part20-arvancloud-abrak/modules/abrak/outputs.tf
+++ b/part20-arvancloud-abrak/modules/abrak/outputs.tf
@@ -1,7 +1,12 @@
 output "ip_addresses" {
-	value = "${arvan_iaas_abrak.abrak.addresses}"
+  value = arvan_iaas_abrak.abrak.addresses
 }
 
 output "id" {
-	value = "${arvan_iaas_abrak.abrak.id}"
+  value = arvan_iaas_abrak.abrak.id
+}
+
+output "ssh_key" {
+  value     = var.abrak_sshkey_enabled ? tls_private_key.sshkey[0].private_key_openssh : null
+  sensitive = true
 }

--- a/part20-arvancloud-abrak/modules/abrak/variables.tf
+++ b/part20-arvancloud-abrak/modules/abrak/variables.tf
@@ -1,6 +1,6 @@
 variable "region" {
-	description = "Arvancloud region name."
-  type = string
+  description = "Arvancloud region name."
+  type        = string
   validation {
     condition = contains(
       [
@@ -9,7 +9,7 @@ variable "region" {
         "ir-thr-w1",  # Bamdad
         "ir-thr-c1"   # Simin
       ],
-			var.region
+      var.region
     )
     error_message = <<-EOF
 		"
@@ -24,31 +24,43 @@ variable "region" {
 }
 
 variable "abrak_name" {
-	description = "Abrak name in Arvancloud web console"
-  type = string
+  description = "Abrak name in Arvancloud web console"
+  type        = string
 }
 
 variable "abrak_flavor" {
-	description = "Abrak plan ID, you can get list of plan IDs of each region from sizes api"
-	# Check "https://napi.arvancloud.ir/ecc/v1/regions/<region>/sizes" to find best falavor size.
-	type = string
+  description = "Abrak plan ID, you can get list of plan IDs of each region from sizes api"
+  # Check "https://napi.arvancloud.ir/ecc/v1/regions/<region>/sizes" to find best falavor size.
+  type = string
 }
 
 variable "abrak_disk_size" {
-	description = "Abrak disk size in GB"
-	type = number
+  description = "Abrak disk size in GB"
+  type        = number
 }
 
 variable "abrak_ha_enabled" {
-	description = "HA feature in abrak. This feature is exprimental, May not works now."
-	type = bool
-  default = false
+  description = "HA feature in abrak. This feature is exprimental, May not works now."
+  type        = bool
+  default     = false
 }
 
 variable "abrak_image" {
-	description = "Abrak image type and name"
-	type = object({
-		type = string
-		name = string
-	})
+  description = "Abrak image type and name"
+  type = object({
+    type = string
+    name = string
+  })
+}
+
+variable "abrak_sshkey_enabled" {
+  description = "Enabled Arvan ssh public key"
+  type        = bool
+  default     = false
+}
+
+variable "abrak_sshkey_name" {
+  description = "Arvan ssh public key name"
+  type        = string
+  default     = "devopshobies"
 }

--- a/part20-arvancloud-abrak/modules/abrak/versions.tf
+++ b/part20-arvancloud-abrak/modules/abrak/versions.tf
@@ -4,5 +4,9 @@ terraform {
       source  = "arvancloud/arvan"
       version = ">=0.6.4"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">=4.0.4"
+    }
   }
 }

--- a/part20-arvancloud-abrak/output.tf
+++ b/part20-arvancloud-abrak/output.tf
@@ -5,3 +5,8 @@ output "abrak_id" {
 output "abrak_ip_addresses" {
   value = module.abrak.ip_addresses
 }
+
+output "abrak_sshkey" {
+  value     = var.abrak_sshkey_enabled ? module.abrak.ssh_key : null
+  sensitive = true
+}

--- a/part20-arvancloud-abrak/variables.tf
+++ b/part20-arvancloud-abrak/variables.tf
@@ -1,15 +1,19 @@
 variable "ApiKey" {
-  type = string
+  type      = string
   sensitive = true
 }
 
 variable "abrak_name" {
-  type = string
+  type    = string
   default = "terraform-abrak-example"
 }
 
 variable "region" {
-  type = string
+  type    = string
   default = "ir-thr-c2" # Forogh Datacenter
 }
 
+variable "abrak_sshkey_enabled" {
+  type    = bool
+  default = true
+}


### PR DESCRIPTION
Add ssh key to arvancloud module

Arvancloud module Options:
✅ simple abrak module
✅ ssh key to simple module

Future works:
🚧 define and configure security groups
🚧 define network subnet and attach to abrak
🚧 define a new volume and attach to Abrak
🚧 complete project README file