### PR TITLE
Add security gorup to arvancloud part

### DIFF
--- a/part20-arvancloud-abrak/main.tf
+++ b/part20-arvancloud-abrak/main.tf
@@ -20,3 +20,30 @@ module "abrak" {
   }
   abrak_disk_size = 25
 }
+
+module "security_group" {
+  source          = "./modules/security_group"
+  sg_name         = "sg-http-access"
+  region          = var.region
+  description     = "Using from devopshobies"
+  attach_to_abrak = false
+  abrak_uuid      = module.abrak.id
+  security_group_rules = [ 
+    {
+      description = "Open http port"
+      direction = "ingress"
+      protocol = "tcp"
+      port_from = "80"
+      port_to = "80"
+      ips = ["0.0.0.0/0"]
+    },
+    {
+      description = "Open https port"
+      direction = "ingress"
+      protocol = "tcp"
+      port_from = "443"
+      port_to = "443"
+      ips = ["0.0.0.0/0"]
+    }
+  ]
+}

--- a/part20-arvancloud-abrak/modules/security_group/README.md
+++ b/part20-arvancloud-abrak/modules/security_group/README.md
@@ -1,0 +1,39 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_arvan"></a> [arvan](#requirement\_arvan) | >=0.6.4 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_arvan"></a> [arvan](#provider\_arvan) | >=0.6.4 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [arvan_iaas_abrak_assign_security_group.security_group_to_abrak](https://registry.terraform.io/providers/arvancloud/arvan/latest/docs/resources/iaas_abrak_assign_security_group) | resource |
+| [arvan_iaas_abrak_remove_security_group.security_group_to_abrak](https://registry.terraform.io/providers/arvancloud/arvan/latest/docs/resources/iaas_abrak_remove_security_group) | resource |
+| [arvan_iaas_security_group.security_group](https://registry.terraform.io/providers/arvancloud/arvan/latest/docs/resources/iaas_security_group) | resource |
+| [arvan_iaas_security_group_rule.security_group_rule](https://registry.terraform.io/providers/arvancloud/arvan/latest/docs/resources/iaas_security_group_rule) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_abrak_uuid"></a> [abrak\_uuid](#input\_abrak\_uuid) | Abrak UUID to attach to security group | `string` | `""` | no |
+| <a name="input_attach_to_abrak"></a> [attach\_to\_abrak](#input\_attach\_to\_abrak) | Disable this vairable when you want to dettach from abrak | `bool` | `true` | no |
+| <a name="input_description"></a> [description](#input\_description) | Description for security gorup | `string` | `"Created from Terrafrom"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Arvancloud region name. | `string` | n/a | yes |
+| <a name="input_security_group_rules"></a> [security\_group\_rules](#input\_security\_group\_rules) | n/a | <pre>list(object({<br>    description = string<br>    direction   = string<br>    protocol    = string<br>    port_from   = string<br>    port_to     = string<br>    ips         = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "description": "Default description from terraform",<br>    "direction": "ingress",<br>    "ips": [],<br>    "port_from": "0",<br>    "port_to": "1024",<br>    "protocol": "tcp"<br>  }<br>]</pre> | no |
+| <a name="input_sg_name"></a> [sg\_name](#input\_sg\_name) | Security group name in Arvancloud web console | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.

--- a/part20-arvancloud-abrak/modules/security_group/main.tf
+++ b/part20-arvancloud-abrak/modules/security_group/main.tf
@@ -1,0 +1,31 @@
+resource "arvan_iaas_security_group" "security_group" {
+  name        = var.sg_name
+  region      = var.region
+  description = var.description
+}
+
+resource "arvan_iaas_security_group_rule" "security_group_rule" {
+  security_group_uuid = arvan_iaas_security_group.security_group.id
+  region              = var.region
+  for_each            = { for id, description in var.security_group_rules : id => description }
+  description         = each.value.description
+  direction           = each.value.direction
+  protocol            = each.value.protocol
+  port_from           = each.value.port_from
+  port_to             = each.value.port_to
+  ips                 = each.value.ips
+}
+
+resource "arvan_iaas_abrak_assign_security_group" "security_group_to_abrak" {
+  count               = var.attach_to_abrak ? 1 : 0
+  region              = var.region
+  security_group_uuid = arvan_iaas_security_group.security_group.id
+  abrak_uuid          = var.abrak_uuid
+}
+
+resource "arvan_iaas_abrak_remove_security_group" "security_group_to_abrak" {
+  count               = var.attach_to_abrak ? 0 : 1
+  region              = var.region
+  security_group_uuid = arvan_iaas_security_group.security_group.id
+  abrak_uuid          = var.abrak_uuid
+}

--- a/part20-arvancloud-abrak/modules/security_group/variables.tf
+++ b/part20-arvancloud-abrak/modules/security_group/variables.tf
@@ -1,0 +1,121 @@
+variable "region" {
+  description = "Arvancloud region name."
+  type        = string
+  validation {
+    condition = contains(
+      [
+        "ir-thr-c2",  # Forogh
+        "ir-tbz-dc1", # Shahriar
+        "ir-thr-w1",  # Bamdad
+        "ir-thr-c1"   # Simin
+      ],
+      var.region
+    )
+    error_message = <<-EOF
+		"
+		Specify valid region name. Using the following available regions.
+		Forogh ==> ir-thr-c2
+		Shahriar ==> ir-tbz-dc1
+		Bamdad ==> ir-thr-w1
+		Simin ==> ir-thr-c1
+		"
+		EOF
+  }
+}
+
+
+variable "sg_name" {
+  description = "Security group name in Arvancloud web console"
+  type        = string
+}
+
+variable "description" {
+  description = "Description for security gorup"
+  type        = string
+  default     = "Created from Terrafrom"
+}
+
+variable "security_group_rules" {
+  type = list(object({
+    description = string
+    direction   = string
+    protocol    = string
+    port_from   = string
+    port_to     = string
+    ips         = list(string)
+  }))
+  default = [
+    {
+      description = "Default description from terraform"
+      direction   = "ingress"
+      protocol    = "tcp"
+      port_from   = "0"
+      port_to     = "1024"
+      ips         = []
+    }
+  ]
+  validation {
+    # Validation for protocol
+    condition = alltrue([
+      for rule in var.security_group_rules : contains(
+        [
+          "tcp",
+          "udp"
+        ],
+        rule.protocol
+      )
+    ])
+    error_message = <<-EOF
+		"
+		Specify valid protocol name. Using the following available protocols.
+		tcp or udp
+		"
+		EOF
+  }
+
+  validation {
+    # Validation for direction
+    condition = alltrue([
+      for rule in var.security_group_rules : contains(
+        [
+          "ingress",
+          "egress"
+        ],
+        rule.direction
+      )
+    ])
+    error_message = <<-EOF
+		"
+		Specify valid direction. Use one of the following:
+		ingress or egress
+		"
+		EOF
+  }
+
+  validation {
+    # Validation for port_from and port_to
+    condition = alltrue([
+      for rule in var.security_group_rules : (
+        tonumber(rule.port_from) >= 0 && tonumber(rule.port_from) <= 65535 &&
+        tonumber(rule.port_to) >= 0 && tonumber(rule.port_to) <= 65535
+      )
+    ])
+    error_message = <<-EOF
+		"
+		Port values must be between 0 and 65535 for both port_from and port_to.
+		"
+		EOF
+  }
+}
+
+variable "abrak_uuid" {
+  description = "Abrak UUID to attach to security group"
+  type        = string
+  default     = ""
+}
+
+variable "attach_to_abrak" {
+  description = "Disable this vairable when you want to dettach from abrak"
+  type        = bool
+  default     = true
+}

--- a/part20-arvancloud-abrak/modules/security_group/versions.tf
+++ b/part20-arvancloud-abrak/modules/security_group/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    arvan = {
+      source  = "arvancloud/arvan"
+      version = ">=0.6.4"
+    }
+  }
+}


### PR DESCRIPTION
Add security group module into base project of arvancloud

Arvancloud module Options:
✅ simple abrak module
✅ ssh key to simple module
✅define and configure security groups

Future works:
🚧 define network subnet and attach to abrak
🚧 define a new volume and attach to Abrak
🚧 complete project README file