### PR TITLE
added script to check docker daemon connection and index.html existence

### DIFF
--- a/part01-docker-provider/index.html
+++ b/part01-docker-provider/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Success</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f0f8ff;
+            color: #333;
+            text-align: center;
+            padding-top: 100px;
+        }
+        h1 {
+            color: #2e8b57;
+        }
+    </style>
+</head>
+<body>
+    <h1>You successfully launched NGINX using Terraform with Docker provider!</h1>
+</body>
+</html>
+

--- a/part01-docker-provider/main.tf
+++ b/part01-docker-provider/main.tf
@@ -10,7 +10,7 @@ resource "docker_image" "nginx" {
 # -> same as 'docker run --name nginx -p8080:80 -d nginx:latest'
 resource "docker_container" "nginx" {
   # The attribute "latest" is deprecated.
-  image      = docker_image.nginx.image_id
+  image      = docker_image.nginx.name
   hostname   = var.container_host_name
   name       = var.container_name
   domainname = var.container_host_name

--- a/part01-docker-provider/prepare-and-deploy.sh
+++ b/part01-docker-provider/prepare-and-deploy.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [ -f "/data/index.html" ]; then
+  echo "Using /data as volume"
+  HOST_PATH="/data"
+else
+  echo "Using current directory as volume"
+  HOST_PATH=$(pwd)
+fi
+
+if nc -z localhost 2376; then
+  DOCKER_HOST="tcp://localhost:2376"
+  echo "Docker TCP socket detected at $DOCKER_HOST"
+else
+  DOCKER_HOST="unix:///var/run/docker.sock"
+  echo "Docker TCP socket not detected, using Unix socket at $DOCKER_HOST"
+fi
+
+terraform plan -var="docker_host=$DOCKER_HOST" -var="host_path=$HOST_PATH"
+read -p "Press Enter to continue with terraform apply or Ctrl+C to cancel..."
+terraform apply -var="docker_host=$DOCKER_HOST" -var="host_path=$HOST_PATH"

--- a/part01-docker-provider/providers.tf
+++ b/part01-docker-provider/providers.tf
@@ -12,5 +12,5 @@ terraform {
 }
 
 provider "docker" {
-  host = "tcp://localhost:2376"
+  host = var.docker_host
 }

--- a/part01-docker-provider/variables.tf
+++ b/part01-docker-provider/variables.tf
@@ -71,3 +71,6 @@ variable "container_network" {
     name   = "nginx_network"
   }
 }
+variable "docker_host" {
+  default = "tcp://localhost:2376"
+}


### PR DESCRIPTION
1. To prevent Terraform failures when applying resources due to Docker daemon connection issues, the provider configuration was made dynamic by passing the connection parameter via a variable using the -var option in Terraform commands.

2. To avoid displaying 403 or 404 errors after applying changes, a check was added in the Bash script that serves a simple HTML file from the current directory as a fallback.