### PR TITLE
Part04/fix arguments

### DIFF
--- a/part01-docker-provider/index.html
+++ b/part01-docker-provider/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Success</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f0f8ff;
+            color: #333;
+            text-align: center;
+            padding-top: 100px;
+        }
+        h1 {
+            color: #2e8b57;
+        }
+    </style>
+</head>
+<body>
+    <h1>You successfully launched NGINX using Terraform with Docker provider!</h1>
+</body>
+</html>
+

--- a/part01-docker-provider/main.tf
+++ b/part01-docker-provider/main.tf
@@ -10,7 +10,7 @@ resource "docker_image" "nginx" {
 # -> same as 'docker run --name nginx -p8080:80 -d nginx:latest'
 resource "docker_container" "nginx" {
   # The attribute "latest" is deprecated.
-  image      = docker_image.nginx.image_id
+  image      = docker_image.nginx.name
   hostname   = var.container_host_name
   name       = var.container_name
   domainname = var.container_host_name

--- a/part01-docker-provider/prepare-and-deploy.sh
+++ b/part01-docker-provider/prepare-and-deploy.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [ -f "/data/index.html" ]; then
+  echo "Using /data as volume"
+  HOST_PATH="/data"
+else
+  echo "Using current directory as volume"
+  HOST_PATH=$(pwd)
+fi
+
+if nc -z localhost 2376; then
+  DOCKER_HOST="tcp://localhost:2376"
+  echo "Docker TCP socket detected at $DOCKER_HOST"
+else
+  DOCKER_HOST="unix:///var/run/docker.sock"
+  echo "Docker TCP socket not detected, using Unix socket at $DOCKER_HOST"
+fi
+
+terraform plan -var="docker_host=$DOCKER_HOST" -var="host_path=$HOST_PATH"
+read -p "Press Enter to continue with terraform apply or Ctrl+C to cancel..."
+terraform apply -var="docker_host=$DOCKER_HOST" -var="host_path=$HOST_PATH"

--- a/part01-docker-provider/providers.tf
+++ b/part01-docker-provider/providers.tf
@@ -12,5 +12,5 @@ terraform {
 }
 
 provider "docker" {
-  host = "tcp://localhost:2376"
+  host = var.docker_host
 }

--- a/part01-docker-provider/variables.tf
+++ b/part01-docker-provider/variables.tf
@@ -71,3 +71,6 @@ variable "container_network" {
     name   = "nginx_network"
   }
 }
+variable "docker_host" {
+  default = "tcp://localhost:2376"
+}

--- a/part04-gitlab-provider/resources.tf
+++ b/part04-gitlab-provider/resources.tf
@@ -16,6 +16,8 @@ resource "gitlab_repository_file" "text" {
   author_email   = var.gitlab_repository_file_details.author_email
   author_name    = var.gitlab_repository_file_details.author_name
   commit_message = var.gitlab_repository_file_details.commit_message
+  encoding       = "text"    
+
 }
 
 resource "gitlab_repository_file" "git" {
@@ -26,6 +28,8 @@ resource "gitlab_repository_file" "git" {
   author_email   = var.gitlab_repository_file_details.author_email
   author_name    = var.gitlab_repository_file_details.author_name
   commit_message = var.gitlab_repository_file_details.commit_message
+  encoding       = "text"    
+
 }
 
 # Manage license
@@ -51,7 +55,7 @@ resource "gitlab_project_tag" "tag" {
 }
 
 # Add a bug label
-resource "gitlab_label" "bug" {
+resource "gitlab_project_label" "bug" {
   name        = "bug"
   color       = "#000" // Set the color
   description = "This label determines that the issue is reporting a bug"
@@ -63,7 +67,7 @@ resource "gitlab_label" "bug" {
 resource "gitlab_pipeline_schedule" "example" {
   project     = gitlab_project.project.id
   description = "Used to schedule builds"
-  ref         = "master"
+  ref         = "refs/heads/main"
   cron        = "0 1 * * *"
 }
 
@@ -71,7 +75,7 @@ resource "gitlab_pipeline_schedule" "example" {
 # Schedule gitlab_pipeline_schedule_variable
 resource "gitlab_pipeline_schedule_variable" "example" {
   project              = gitlab_project.project.id
-  pipeline_schedule_id = gitlab_pipeline_schedule.example.id
+  pipeline_schedule_id = gitlab_pipeline_schedule.example.pipeline_schedule_id
   key                  = "EXAMPLE_KEY"
   value                = "example"
 }

--- a/part04-gitlab-provider/variables.tf
+++ b/part04-gitlab-provider/variables.tf
@@ -1,6 +1,6 @@
 variable "gitlab_token" {
   type    = string
-  default = ""
+  default = "glpat-*******"
 }
 
 variable "branch_name" {


### PR DESCRIPTION
1.Missing encoding arguments in the gitlab_repository_file resource for <text> and <git> caused Terraform to fail.
2.The gitlab_label resource was deprecated and replaced with gitlab_project_label.
3.Updated the gitlab_pipeline_schedule resource by changing the ref argument from main to refs/heads/main to prevent inconsistencies.
4.Fixed the gitlab_pipeline_schedule_variable resource, which was previously linked to the wrong pipeline_schedule.